### PR TITLE
Show brand names when pairing device

### DIFF
--- a/i2app/i2app/CatalogBrandListCell.swift
+++ b/i2app/i2app/CatalogBrandListCell.swift
@@ -32,7 +32,12 @@ class CatalogBrandListCell: UITableViewCell {
    Image for the brand.
    */
   @IBOutlet weak var brandImage: UIImageView!
-  
+
+  /**
+   Device's vendor.
+   */
+  @IBOutlet weak var brandName: UILabel!
+
   /**
    Count of devices available in the brand.
    */

--- a/i2app/i2app/CatalogBrandListViewController.swift
+++ b/i2app/i2app/CatalogBrandListViewController.swift
@@ -237,6 +237,7 @@ extension CatalogBrandListViewController: UITableViewDataSource {
 
   private func bind(_ cell: CatalogBrandListCell, viewModel: CatalogBrandViewModel) {
     cell.deviceCount.text = "\(viewModel.productList.count)"
+    cell.brandName.text = "\(viewModel.name)"
     cell.brandImage.sd_setImage(with: viewModel.imageURL)
   }
 }

--- a/i2app/i2app/PairingCatalog.storyboard
+++ b/i2app/i2app/PairingCatalog.storyboard
@@ -169,6 +169,13 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Brand Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ad-hs-Re2" userLabel="Device Name">
+                                                    <rect key="frame" x="0.0" y="0.0" width="237" height="27.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="14"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CheckmarkEmptyIcon" translatesAutoresizingMaskIntoConstraints="NO" id="t41-P6-YAm">
                                                     <rect key="frame" x="27" y="30" width="30" height="30"/>
                                                 </imageView>
@@ -192,6 +199,7 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="brandImage" destination="t41-P6-YAm" id="u3w-B6-M6N"/>
+                                            <outlet property="brandName" destination="9ad-hs-Re2" id="b1c-1Y-XXz"/>
                                             <outlet property="deviceCount" destination="rrf-rR-Gm9" id="h6V-s6-hRJ"/>
                                             <segue destination="efo-TV-bQz" kind="show" identifier="showDeviceList" id="XfK-Xr-m6G"/>
                                         </connections>

--- a/i2app/i2app/PairingCatalog.storyboard
+++ b/i2app/i2app/PairingCatalog.storyboard
@@ -169,13 +169,6 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Brand Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ad-hs-Re2" userLabel="Device Name">
-                                                    <rect key="frame" x="0.0" y="0.0" width="237" height="27.5"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="14"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CheckmarkEmptyIcon" translatesAutoresizingMaskIntoConstraints="NO" id="t41-P6-YAm">
                                                     <rect key="frame" x="27" y="30" width="30" height="30"/>
                                                 </imageView>
@@ -186,6 +179,13 @@
                                                         <constraint firstAttribute="width" constant="8" id="wwK-n9-fvk"/>
                                                     </constraints>
                                                 </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Brand Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ad-hs-Re2" userLabel="Device Name">
+                                                    <rect key="frame" x="95" y="31" width="237" height="27.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="14"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="rrf-rR-Gm9" firstAttribute="centerY" secondItem="Z8p-LB-wwb" secondAttribute="centerY" id="1tV-cZ-OYm"/>

--- a/i2app/i2app/UI/ViewControllers/DeviceBrandTableViewCell.h
+++ b/i2app/i2app/UI/ViewControllers/DeviceBrandTableViewCell.h
@@ -29,6 +29,7 @@
 
 @property (nonatomic, strong) IBOutlet UIImageView *brandImage;
 @property (nonatomic, strong) IBOutlet UIImageView *disclosureImage;
+@property (nonatomic, strong) IBOutlet UILabel *brandName;
 @property (nonatomic, strong) IBOutlet UILabel *countLabel;
 
 - (void)setMarked:(BOOL)marked;


### PR DESCRIPTION
The brand images were left out of the open source release. Until they can be replaced, show the brand name to allow the user to find devices to pair:

![Screen Shot 2019-10-02 at 9 14 22 PM](https://user-images.githubusercontent.com/198195/66098980-9f5c7f00-e559-11e9-964e-2b0769a1a0a9.png)
