### PR TITLE
Fix i2app-ad-hoc build

### DIFF
--- a/i2app/i2app.xcodeproj/xcshareddata/xcschemes/i2app-ad-hoc.xcscheme
+++ b/i2app/i2app.xcodeproj/xcshareddata/xcschemes/i2app-ad-hoc.xcscheme
@@ -7,6 +7,20 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F230E3B11ACAEF8F005D953A"
+               BuildableName = "i2app.app"
+               BlueprintName = "i2app"
+               ReferencedContainer = "container:i2app.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
@@ -26,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -46,7 +59,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/i2app/i2app.xcodeproj/xcshareddata/xcschemes/i2app-ad-hoc.xcscheme
+++ b/i2app/i2app.xcodeproj/xcshareddata/xcschemes/i2app-ad-hoc.xcscheme
@@ -7,20 +7,6 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "NO"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F230E3B11ACAEF8F005D953A"
-               BuildableName = "i2app.app"
-               BlueprintName = "i2app"
-               ReferencedContainer = "container:i2app.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
@@ -31,6 +17,20 @@
                BlueprintIdentifier = "CBC201151D6DF4E4004B2469"
                BuildableName = "i2app-ad-hoc.app"
                BlueprintName = "i2app-ad-hoc"
+               ReferencedContainer = "container:i2app.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F230E3B11ACAEF8F005D953A"
+               BuildableName = "i2app.app"
+               BlueprintName = "i2app"
                ReferencedContainer = "container:i2app.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -46,9 +46,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CBC201151D6DF4E4004B2469"
-            BuildableName = "i2app-ad-hoc.app"
-            BlueprintName = "i2app-ad-hoc"
+            BlueprintIdentifier = "F230E3B11ACAEF8F005D953A"
+            BuildableName = "i2app.app"
+            BlueprintName = "i2app"
             ReferencedContainer = "container:i2app.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -69,9 +69,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CBC201151D6DF4E4004B2469"
-            BuildableName = "i2app-ad-hoc.app"
-            BlueprintName = "i2app-ad-hoc"
+            BlueprintIdentifier = "F230E3B11ACAEF8F005D953A"
+            BuildableName = "i2app.app"
+            BlueprintName = "i2app"
             ReferencedContainer = "container:i2app.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>


### PR DESCRIPTION
Allow the app to built with i2app-ad-hoc, instead of only with the original i2app-CI schema.